### PR TITLE
Re-add MathJax config

### DIFF
--- a/templates/default.html
+++ b/templates/default.html
@@ -6,7 +6,7 @@
     <title>$title$</title>
 
     <link rel="stylesheet" href="/css/main.min.css">
-    <script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.3/MathJax.js'></script>
+    <script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.3/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <!-- Matomo -->


### PR DESCRIPTION
This re-adds the MathJax config that was removed in https://github.com/wei2912/blog-src/commit/4fe3eb4a15a184e899eb6245760be90ccd249cf5#diff-456a69052615a663e52659628e6583a8L9

Without it, MathJax won't render anything.