### PR TITLE
Content Tracking on Posts in Matomo

### DIFF
--- a/templates/default.html
+++ b/templates/default.html
@@ -22,6 +22,9 @@
         var u="//weien.io/matomo/";
         _paq.push(['setTrackerUrl', u+'piwik.php']);
         _paq.push(['setSiteId', '1']);
+        _paq.push(['enableLinkTracking']);
+        _paq.push(['trackPageView']);
+        _paq.push(['trackAllContentImpressions']);
         var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
         g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
       })();


### PR DESCRIPTION
Matomo allows for [Content Tracking](https://developer.matomo.org/guides/content-tracking) which can be deployed on interactive posts to track how users engage with the content.